### PR TITLE
feat: Add cspell checking

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -5,6 +5,12 @@ on:
   workflow_dispatch:
   
 jobs:
+  cspell:
+    name: 🔤 Check Spelling
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/spell_check.yml@v1
+    with:
+        config: cspell.config.yaml
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,3 +1,4 @@
+# cspell:words subosito
 name: build_and_test
 on:
   pull_request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Ensure that your contributions include appropriate tests and that all existing t
 
 Unit tests are not enough. All UI changes require widget tests, and even better if those widget tests double as integration tests.
 
-It's sually a good idea to capture at least one golden of the charts, and there are plenty of examples of that in the existing tests.
+It's usually a good idea to capture at least one golden of the charts, and there are plenty of examples of that in the existing tests.
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is a resurrection of the discontinued [charts_flutter](https://pub.
 
 ### Dart 3, Type Safety, Tests, and Bug Fixes
 
-Type safety and rigourous tests ensure that this package is reliable and maintainable. We applied thousands of automatic and manual fixes to the code to bring type safety up, and ensure that it's harder to break this library. There are also many new widget tests with goldens, which means that changes should not affect the UI behavior.
+Type safety and rigorous tests ensure that this package is reliable and maintainable. We applied thousands of automatic and manual fixes to the code to bring type safety up, and ensure that it's harder to break this library. There are also many new widget tests with goldens, which means that changes should not affect the UI behavior.
 
 This fork provides the most solid foundation for future development, and we will continue to maintain this library.
 

--- a/charts_common/README.md
+++ b/charts_common/README.md
@@ -15,7 +15,7 @@ This project is a resurrection of the discontinued [charts_flutter](https://pub.
 
 ### Dart 3, Type Safety, Tests, and Bug Fixes
 
-Type safety and rigourous tests ensure that this package is reliable and maintainable. We applied thousands of automatic and manual fixes to the code to bring type safety up, and ensure that it's harder to break this library. There are also many new widget tests with goldens, which means that changes should not affect the UI behavior.
+Type safety and rigorous tests ensure that this package is reliable and maintainable. We applied thousands of automatic and manual fixes to the code to bring type safety up, and ensure that it's harder to break this library. There are also many new widget tests with goldens, which means that changes should not affect the UI behavior.
 
 This fork provides the most solid foundation for future development, and we will continue to maintain this library.
 

--- a/charts_common/analysis_options.yaml
+++ b/charts_common/analysis_options.yaml
@@ -1,3 +1,4 @@
+# cspell:words runtimetype tostring
 include: package:austerity/analysis_options.yaml
 
 analyzer:

--- a/charts_common/lib/src/chart/bar/bar_label_decorator.dart
+++ b/charts_common/lib/src/chart/bar/bar_label_decorator.dart
@@ -444,7 +444,7 @@ class BarLabelDecorator<D> extends BarRendererDecorator<D> {
         : defaultStyle;
   }
 
-  /// Helper function to get the bar label anchor when BarLabelPostion is
+  /// Helper function to get the bar label anchor when BarLabelPosition is
   /// inside.
   BarLabelAnchor _resolveLabelAnchor(num measure, BarLabelAnchor anchor) {
     if (labelPlacement == BarLabelPlacement.opposeAxisBaseline) {
@@ -484,7 +484,7 @@ enum BarLabelPlacement {
   followMeasureAxis,
 
   /// Places the label with respect to the zero baseline. The bar end is the
-  /// absolute value aways from the zero baseline.
+  /// absolute value always from the zero baseline.
   opposeAxisBaseline,
 }
 

--- a/charts_common/lib/src/chart/bar/base_bar_renderer.dart
+++ b/charts_common/lib/src/chart/bar/base_bar_renderer.dart
@@ -426,7 +426,7 @@ abstract class BaseBarRenderer<D, R extends BaseBarRendererElement,
 
         final barStackList = _barStackMap.putIfAbsent(barStackMapKey, () => []);
 
-        // If we already have an AnimatingBarfor that index, use it.
+        // If we already have an AnimatingBar for that index, use it.
         var animatingBar =
             barStackList.firstWhereOrNull((bar) => bar.key == barKey);
 
@@ -830,7 +830,7 @@ abstract class BaseBarRenderer<D, R extends BaseBarRendererElement,
   bool get isRtl => chart.context.isRtl;
 }
 
-/// Iterable wrapping the seriesList that returns the ReversedSeriesItertor.
+/// Iterable wrapping the seriesList that returns the ReversedSeriesIterator.
 class _ReversedSeriesIterable<S extends ImmutableSeries<Object?>>
     extends Iterable<S> {
   _ReversedSeriesIterable(this.seriesList);

--- a/charts_common/lib/src/chart/bar/base_bar_renderer_config.dart
+++ b/charts_common/lib/src/chart/bar/base_bar_renderer_config.dart
@@ -156,7 +156,7 @@ abstract class BaseBarRendererConfig<D> extends LayoutViewConfig
   }
 }
 
-/// Defines the way multiple series of bars are renderered per domain.
+/// Defines the way multiple series of bars are rendered per domain.
 ///
 /// * [grouped] - Render bars for each series that shares a domain value
 ///   side-by-side.

--- a/charts_common/lib/src/chart/cartesian/axis/axis.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/axis.dart
@@ -240,7 +240,7 @@ abstract class Axis<D> extends ImmutableAxis<D> implements LayoutView {
       final domainLocation = scale[domain]!.toDouble();
 
       // If domain location is outside of scale range but only outside by less
-      // than epsilon, correct the potential mislocation caused by floating
+      // than epsilon, correct the potential mis-location caused by floating
       // point computation by moving it inside of scale range.
       if (domainLocation > range.max && domainLocation - epsilon < range.max) {
         return domainLocation - epsilon;

--- a/charts_common/lib/src/chart/cartesian/axis/draw_strategy/range_tick_draw_strategy.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/draw_strategy/range_tick_draw_strategy.dart
@@ -89,7 +89,7 @@ class RangeTickRendererSpec<D> extends SmallTickRendererSpec<D> {
   final int? rangeTickLengthPx;
   // Specifies range shade's height.
   final int? rangeShadeHeightPx;
-  // Specifies the starting offet of range shade from axis in pixels.
+  // Specifies the starting offset of range shade from axis in pixels.
   final int? rangeShadeOffsetFromAxisPx;
   // A range tick offset from the original location. The start point offset is
   // toward the origin and end point offset is toward the end of axis.
@@ -268,7 +268,7 @@ class RangeTickDrawStrategy<D> extends SmallTickDrawStrategy<D> {
                   getLabelWidth(labelElements),
                 ) +
                 labelOffsetFromAxisPx(collision: collision),
-            //TODO: possible precission loss
+            //TODO: possible precision loss
           ).toInt(),
           labelOffsetFromAxisPx(collision: collision) + rangeShadeHeightPx,
         );
@@ -281,7 +281,7 @@ class RangeTickDrawStrategy<D> extends SmallTickDrawStrategy<D> {
                 getLabelWidth(labelElements),
               ) +
               labelOffsetFromAxisPx(collision: collision),
-          //TODO: possible precission loss
+          //TODO: possible precision loss
         ).toInt();
       }
     });
@@ -314,7 +314,7 @@ class RangeTickDrawStrategy<D> extends SmallTickDrawStrategy<D> {
                   getLabelWidth(labelElements),
                 ) +
                 rangeShadeOffsetFromAxisPx,
-            //TODO: possible precission loss
+            //TODO: possible precision loss
           ).toInt(),
           rangeShadeOffsetFromAxisPx + rangeShadeHeightPx,
         );
@@ -326,7 +326,7 @@ class RangeTickDrawStrategy<D> extends SmallTickDrawStrategy<D> {
                 getLabelHeight(labelElements),
                 getLabelWidth(labelElements),
               ),
-              //TODO: possible precission loss
+              //TODO: possible precision loss
             ).toInt() +
             labelOffsetFromAxisPx(collision: collision);
       }

--- a/charts_common/lib/src/chart/common/behavior/a11y/keyboard_domain_navigator.dart
+++ b/charts_common/lib/src/chart/common/behavior/a11y/keyboard_domain_navigator.dart
@@ -221,7 +221,7 @@ abstract class KeyboardDomainNavigator<D> implements ChartBehavior<D> {
     }
 
     // If the currentIndex is the same as the firstSelectedDetail we don't have
-    // to do a linear seach to find the domain.
+    // to do a linear search to find the domain.
     final firstDomain = details.first.domain as D;
 
     if (0 <= _currentIndex &&

--- a/charts_common/lib/src/chart/common/behavior/selection/lock_selection.dart
+++ b/charts_common/lib/src/chart/common/behavior/selection/lock_selection.dart
@@ -17,7 +17,7 @@ import 'dart:math';
 
 import 'package:nimble_charts_common/common.dart';
 
-/// Chart behavior that listens to tap event trigges and locks the specified
+/// Chart behavior that listens to tap event triggers and locks the specified
 /// [SelectionModel]. This is used to prevent further updates to the selection
 /// model, until it is unlocked again.
 ///

--- a/charts_common/lib/src/chart/layout/layout_manager_impl.dart
+++ b/charts_common/lib/src/chart/layout/layout_manager_impl.dart
@@ -29,7 +29,7 @@ class LayoutManagerImpl implements LayoutManager {
   static const _minDrawWidth = 20;
   static const _minDrawHeight = 20;
 
-  // Allow [Layoutconfig] to be mutable so it can be modified without requiring
+  // Allow [LayoutConfig] to be mutable so it can be modified without requiring
   // a new copy of [DefaultLayoutManager] to be created.
   LayoutConfig config;
 

--- a/charts_common/lib/src/chart/pie/arc_label_decorator.dart
+++ b/charts_common/lib/src/chart/pie/arc_label_decorator.dart
@@ -219,7 +219,7 @@ class ArcLabelDecorator<D> extends ArcRendererDecorator<D> {
     TextStyle labelStyle,
     int insideArcWidth,
     int outsideArcWidth,
-    ArcRendererElement arcRendererelement,
+    ArcRendererElement arcRendererElement,
     ArcLabelPosition labelPosition,
   ) {
     if (labelPosition == ArcLabelPosition.auto) {
@@ -312,7 +312,7 @@ class ArcLabelDecorator<D> extends ArcRendererDecorator<D> {
       arcElements.center.y + labelRadius * sin(centerAngle),
     );
 
-    // Use the label's chart quandrant to determine whether it's rendered to the
+    // Use the label's chart quadrant to determine whether it's rendered to the
     // right or left.
     final centerAbs = centerAngle.abs() % (2 * pi);
     final labelLeftOfChart = pi / 2 < centerAbs && centerAbs < pi * 3 / 2;

--- a/charts_common/lib/src/chart/sunburst/sunburst_arc_label_decorator.dart
+++ b/charts_common/lib/src/chart/sunburst/sunburst_arc_label_decorator.dart
@@ -167,28 +167,28 @@ class SunburstArcLabelDecorator<D> extends ArcLabelDecorator<D> {
     TextStyle labelStyle,
     int insideArcWidth,
     int outsideArcWidth,
-    ArcRendererElement arcRendererelement,
+    ArcRendererElement arcRendererElement,
     ArcLabelPosition labelPosition,
   ) {
-    assert(arcRendererelement is SunburstArcRendererElement);
+    assert(arcRendererElement is SunburstArcRendererElement);
 
-    if ((arcRendererelement as SunburstArcRendererElement).isOuterMostRing ==
+    if ((arcRendererElement as SunburstArcRendererElement).isOuterMostRing ==
         true) {
       return super.calculateLabelPosition(
         labelElement,
         labelStyle,
         insideArcWidth,
         outsideArcWidth,
-        arcRendererelement,
+        arcRendererElement,
         outerRingArcLabelPosition,
       );
-    } else if (arcRendererelement.isLeaf == true) {
+    } else if (arcRendererElement.isLeaf == true) {
       return super.calculateLabelPosition(
         labelElement,
         labelStyle,
         insideArcWidth,
         outsideArcWidth,
-        arcRendererelement,
+        arcRendererElement,
         innerRingLeafArcLabelPosition,
       );
     } else {

--- a/charts_common/lib/src/chart/sunburst/sunburst_arc_renderer_config.dart
+++ b/charts_common/lib/src/chart/sunburst/sunburst_arc_renderer_config.dart
@@ -84,7 +84,7 @@ class SunburstArcRendererConfig<D> extends BaseArcRendererConfig<D> {
       SunburstArcRenderer<D>(config: this, rendererId: customRendererId);
 }
 
-/// Strategies for assinging color to the arcs if colorFn is not provided for
+/// Strategies for assigning color to the arcs if colorFn is not provided for
 /// Series.
 enum SunburstColorStrategy {
   /// Assign a new shade to each of the arcs.

--- a/charts_common/lib/src/chart/treemap/treemap_label_decorator.dart
+++ b/charts_common/lib/src/chart/treemap/treemap_label_decorator.dart
@@ -120,7 +120,7 @@ class TreeMapLabelDecorator<D> extends TreeMapRendererDecorator<D> {
       // Draws a label inside of a treemap renderer element.
       canvas.drawText(
         segment.text,
-        segment.xOffet,
+        segment.xOffset,
         segment.yOffset,
         rotation: segment.rotationAngle,
       );
@@ -197,7 +197,7 @@ class TreeMapLabelDecorator<D> extends TreeMapRendererDecorator<D> {
 class _TreeMapLabelSegment {
   _TreeMapLabelSegment(
     this.text,
-    this.xOffet,
+    this.xOffset,
     this.yOffset,
     this.rotationAngle,
   );
@@ -206,7 +206,7 @@ class _TreeMapLabelSegment {
   final TextElement text;
 
   /// x-coordinate offset for [text].
-  final int xOffet;
+  final int xOffset;
 
   /// y-coordinate offset for [text].
   final int yOffset;

--- a/charts_common/lib/src/common/gesture_listener.dart
+++ b/charts_common/lib/src/common/gesture_listener.dart
@@ -76,7 +76,7 @@ class GestureListener {
   /// Called when the chart is focused.
   final GestureCallback? onFocus;
 
-  /// Called when the chart is blured.
+  /// Called when the chart is blurred.
   final GestureCallback? onBlur;
 
   /// Called when the tap event has moved beyond a threshold indicating that

--- a/charts_common/lib/src/data/graph.dart
+++ b/charts_common/lib/src/data/graph.dart
@@ -277,7 +277,7 @@ class Link<N, L> extends GraphElement<L> {
 List<Link<N, L>> _cloneLinkList<N, L>(List<Link<N, L>> linkList) =>
     linkList.map(Link.clone).toList();
 
-/// A [Link] or [Node] elmeent in a graph containing user defined data.
+/// A [Link] or [Node] element in a graph containing user defined data.
 abstract class GraphElement<G> {
   GraphElement(this.data);
 

--- a/charts_common/test/chart/bar/bar_label_decorator_test.dart
+++ b/charts_common/test/chart/bar/bar_label_decorator_test.dart
@@ -256,8 +256,8 @@ void main() {
     });
 
     test('LabelPosition.inside always paints inside the bar', () {
-      //This code looks like it does nothing, but the weird mutable
-      //heirarchy means that it's necessary.
+      // This code looks like it does nothing, but the weird mutable
+      // hierarchy means that it's necessary.
       final barElements = [
         // 'LabelABC' would not fit inside the bar in auto setting because it
         // has a width of 8.
@@ -855,8 +855,8 @@ void main() {
     test('Inside and outside label styles are applied', () {
       final data = ['A', 'B'];
 
-      //This code looks like it does nothing, but the weird mutable
-      //heirarchy means that it's necessary.
+      // This code looks like it does nothing, but the weird mutable
+      // hierarchy means that it's necessary.
       // ignore: unused_local_variable
       final barElements = [
         // 'LabelA' and 'LabelB' both have lengths of 6.

--- a/charts_common/test/chart/cartesian/axis/time/date_time_tick_formatter_test.dart
+++ b/charts_common/test/chart/cartesian/axis/time/date_time_tick_formatter_test.dart
@@ -176,7 +176,7 @@ void main() {
       expect(actualLabels, equals(expectedLabels));
     });
 
-    test('on empty input doesnt break', () {
+    test('on empty input does not break', () {
       final formatter =
           DateTimeTickFormatter.withFormatters({10: timeFormatter1});
       final formatterCache = <DateTime, String>{};
@@ -218,7 +218,7 @@ void main() {
   });
 
   group('check custom time tick formatters', () {
-    test('throws arugment error if time resolution key is not positive', () {
+    test('throws argument error if time resolution key is not positive', () {
       // -1 is reserved for any, if there is only one formatter, -1 is allowed.
       expect(
         () => DateTimeTickFormatter.withFormatters(
@@ -235,7 +235,7 @@ void main() {
       );
     });
 
-    test('throws arugment error if formatters are not sorted', () {
+    test('throws argument error if formatters are not sorted', () {
       expect(
         () => DateTimeTickFormatter.withFormatters({
           3: timeFormatter1,

--- a/charts_common/test/common/text_utils_test.dart
+++ b/charts_common/test/common/text_utils_test.dart
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// cspell:words texttexttexttext texttextte xttext
+
 import 'package:mockito/mockito.dart';
 import 'package:nimble_charts_common/src/common/color.dart' show Color;
 import 'package:nimble_charts_common/src/common/graphics_factory.dart'
@@ -149,6 +151,7 @@ void main() {
     test(
         'when label can not fit in a single line, enable allowLabelOverflow, '
         'disable multiline, return ellipsized text', () {
+      // cspell:disable-next-line
       final textElement = FakeTextElement('texttexttexttext')
         ..textStyle = textStyle;
       final textElements = wrapLabelLines(
@@ -161,6 +164,7 @@ void main() {
       );
 
       expect(textElements, hasLength(1));
+      // cspell:disable-next-line
       expect(textElements.first.text, 'textte...');
     });
 
@@ -184,7 +188,7 @@ void main() {
     });
 
     test(
-        'when both label and ellpisis can not fit in a single line, disable '
+        'when both label and ellipsis can not fit in a single line, disable '
         'allowLabelOverflow and multiline, return empty', () {
       const maxWidth = 2;
       final textElement = FakeTextElement('texttexttexttext')
@@ -202,7 +206,7 @@ void main() {
     });
 
     test(
-        'when both label and ellpisis can not fit in a single line, disable '
+        'when both label and ellipsis can not fit in a single line, disable '
         'allowLabelOverflow but enable multiline, return textElements', () {
       const maxWidth = 2;
       final textElement = FakeTextElement('t ex text')..textStyle = textStyle;

--- a/charts_flutter/README.md
+++ b/charts_flutter/README.md
@@ -13,7 +13,7 @@ This project is a resurrection of the discontinued [charts_flutter](https://pub.
 
 ### Dart 3, Type Safety, Tests, and Bug Fixes
 
-Type safety and rigourous tests ensure that this package is reliable and maintainable. We applied thousands of automatic and manual fixes to the code to bring type safety up, and ensure that it's harder to break this library. There are also many new widget tests with goldens, which means that changes should not affect the UI behavior.
+Type safety and rigorous tests ensure that this package is reliable and maintainable. We applied thousands of automatic and manual fixes to the code to bring type safety up, and ensure that it's harder to break this library. There are also many new widget tests with goldens, which means that changes should not affect the UI behavior.
 
 This fork provides the most solid foundation for future development, and we will continue to maintain this library.
 

--- a/charts_flutter/analysis_options.yaml
+++ b/charts_flutter/analysis_options.yaml
@@ -1,3 +1,5 @@
+#cspell:words runtimetype tostring
+
 include: package:austerity/analysis_options.yaml
 
 analyzer:

--- a/charts_flutter/lib/src/behaviors/legend/legend_entry_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_entry_layout.dart
@@ -143,7 +143,7 @@ class SimpleLegendEntryLayout implements LegendEntryLayout {
   @override
   int get hashCode => runtimeType.hashCode;
 
-  /// Convert the charts common TextStlyeSpec into a standard TextStyle, while
+  /// Convert the charts common TextStyleSpec into a standard TextStyle, while
   /// reducing the color opacity to 26% if the entry is hidden.
   ///
   /// For non-specified values, override the hidden text color to use the body 1

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -14,47 +14,49 @@ ignorePaths:
   - "charts_common/test/data/"
   - 'coverage'
 words:
-- pubspec
+- Aplos # Group inside Google which wrote the original flutter_charts.
+- barchart
+- cbraun
+- credentialless # CORS policy name (in serve.json for web)
+- cupertino
+- dasharray
+- defaultlabel # Probably could be capitalized
+- ellipsize
+- ellipsized
+- Findlay
+- focusable
+- Gemlock
 - genhtml
 - goldens
-- hotfixes
-- dasharray
-- hashcode
-- LTWH
-- barchart
-- gridlines
-- gridline
-- cupertino
 - gradlew
-- squarified
-- Squarify
-- Sankey
+- gridline
+- gridlines
+- hashcode
+- hotfixes
 - hovercard
-- Outliner
-- treemap
-- ellipsized
-- nonclaiming
-- Unlisten
-- cbraun
-- Treemaps
-- unitconverter # Probably could be capitalized
-- ellipsize
-- defaultlabel # Probably could be capitalized
-- Nimblesite
-- squarification
-- Rangeband
-- OPENSOURCE
-- Gemlock
-- Findlay
-- Statick
+- Jaspr
+- LTWH
 - niced
 - nicing
-- Jaspr
-- Postrender # Probably could be capitalized
-- stylepack
+- Nimblesite
+- nonclaiming
+- OPENSOURCE
+- Outliner
 - paintable
-- TRBL
-- Aplos # Group inside Google which wrote the original flutter_charts.
-- tostring # Used in a lint name
+- Postrender # Probably could be capitalized
+- pubspec
+- Rangeband
 - RRGGBB # Color format
-- credentialless # CORS policy name (in serve.json for web)
+- Sankey
+- squarification
+- squarified
+- Squarify
+- Statick
+- stylepack
+- tappable
+- tostring # Used in a lint name
+- TRBL
+- treemap
+- Treemaps
+- unitconverter # Probably could be capitalized
+- Unlisten

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,60 @@
+$schema: https://raw.githubusercontent.com/streetsidesoftware/cspell/main/cspell.schema.json
+version: "0.2"
+ignorePaths:
+  # Various platform-specific API names we can just ignore.
+  - charts_flutter/example/windows/
+  - charts_flutter/example/macos/
+  - charts_flutter/example/ios/
+  - charts_flutter/example/linux/
+  - charts_flutter/example/android/
+  - "gradlew"
+  - "gradlew.bat"
+  - "build"
+  - "*.iml"
+  - "charts_common/test/data/"
+  - 'coverage'
+words:
+- pubspec
+- genhtml
+- goldens
+- hotfixes
+- dasharray
+- hashcode
+- LTWH
+- barchart
+- gridlines
+- gridline
+- cupertino
+- gradlew
+- squarified
+- Squarify
+- Sankey
+- hovercard
+- Outliner
+- treemap
+- ellipsized
+- nonclaiming
+- Unlisten
+- cbraun
+- Treemaps
+- unitconverter # Probably could be capitalized
+- ellipsize
+- defaultlabel # Probably could be capitalized
+- Nimblesite
+- squarification
+- Rangeband
+- OPENSOURCE
+- Gemlock
+- Findlay
+- Statick
+- niced
+- nicing
+- Jaspr
+- Postrender # Probably could be capitalized
+- stylepack
+- paintable
+- TRBL
+- Aplos # Group inside Google which wrote the original flutter_charts.
+- tostring # Used in a lint name
+- RRGGBB # Color format
+- credentialless # CORS policy name (in serve.json for web)


### PR DESCRIPTION
This adds a cspell config and fixes all outstanding spelling errors.

There are a few small code changes, but they are only to private
variable names so this should not have any user-visible effect.

Most of the changes are simply fixing typos in comments.