### PR TITLE
chore: remove unnecessary switch default clauses

### DIFF
--- a/charts_common/analysis_options.yaml
+++ b/charts_common/analysis_options.yaml
@@ -1,4 +1,4 @@
-# cspell:words runtimetype tostring
+# cspell:words runtimetype tostring bools
 include: package:austerity/analysis_options.yaml
 
 analyzer:

--- a/charts_common/lib/src/chart/cartesian/axis/axis.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/axis.dart
@@ -668,11 +668,7 @@ class OrdinalViewport {
       dataSize == other.dataSize;
 
   @override
-  int get hashCode {
-    var hashcode = startingDomain.hashCode;
-    hashcode = (hashcode * 37) + dataSize;
-    return hashcode;
-  }
+  int get hashCode => startingDomain.hashCode * 37 + dataSize;
 }
 
 @visibleForTesting

--- a/charts_common/lib/src/chart/cartesian/axis/axis_tick.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/axis_tick.dart
@@ -100,11 +100,24 @@ class AxisTicks<D> extends Tick<D> implements Comparable<AxisTicks<D>> {
   /// Linearly interpolate between two numbers.
   ///
   /// From lerpDouble in dart:ui which is Flutter only.
-  double? _lerpDouble(double? a, double? b, double t) {
-    if (a == null && b == null) return null;
+  double? _lerpDouble(num? maybeA, num? maybeB, double t) {
+    var a = maybeA;
+    var b = maybeB;
+    if (a == b || (a?.isNaN ?? false) && (b?.isNaN ?? false)) {
+      return a?.toDouble();
+    }
     a ??= 0.0;
     b ??= 0.0;
-    return a + (b - a) * t;
+    assert(
+      a.isFinite,
+      'Cannot interpolate between finite and non-finite values',
+    );
+    assert(
+      b.isFinite,
+      'Cannot interpolate between finite and non-finite values',
+    );
+    assert(t.isFinite, 't must be finite when interpolating between values');
+    return a * (1.0 - t) + b * t;
   }
 
   @override

--- a/charts_common/lib/src/chart/cartesian/axis/draw_strategy/base_tick_draw_strategy.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/draw_strategy/base_tick_draw_strategy.dart
@@ -514,9 +514,7 @@ abstract class BaseTickDrawStrategy<D> implements TickDrawStrategy<D> {
                     labelOffsetPx)
                 .toInt();
           case TextDirection.center:
-          default:
             x = (locationPx - labelOffsetPx).toInt();
-            break;
         }
       } else {
         if (orientation == AxisOrientation.left) {
@@ -555,9 +553,7 @@ abstract class BaseTickDrawStrategy<D> implements TickDrawStrategy<D> {
                     labelOffsetPx)
                 .toInt();
           case PixelVerticalDirection.center:
-          default:
             y = (locationPx - labelHeight / 2 + labelOffsetPx).toInt();
-            break;
         }
       }
       canvas.drawText(
@@ -591,7 +587,6 @@ abstract class BaseTickDrawStrategy<D> implements TickDrawStrategy<D> {
         }
         return TextDirection.center;
       case TickLabelAnchor.centered:
-      default:
         return TextDirection.center;
     }
   }
@@ -616,7 +611,6 @@ abstract class BaseTickDrawStrategy<D> implements TickDrawStrategy<D> {
         }
         return PixelVerticalDirection.center;
       case TickLabelAnchor.centered:
-      default:
         return PixelVerticalDirection.center;
     }
   }

--- a/charts_common/lib/src/chart/cartesian/axis/draw_strategy/range_tick_draw_strategy.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/draw_strategy/range_tick_draw_strategy.dart
@@ -254,7 +254,7 @@ class RangeTickDrawStrategy<D> extends SmallTickDrawStrategy<D> {
     // text and the axis baseline (even if it isn't drawn).
 
     final maxHorizontalSliceWidth = ticks.fold(0, (prevMax, tick) {
-      assert(tick.textElement != null);
+      assert(tick.textElement != null, 'Tick text element is null.');
       final labelElements = splitLabel(tick.textElement!);
       if (tick is RangeAxisTicks) {
         // Find the maximum within prevMax, label total height and

--- a/charts_common/lib/src/chart/cartesian/axis/linear/linear_scale.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/linear/linear_scale.dart
@@ -221,7 +221,7 @@ class LinearScale implements NumericScale {
   void _configureScale() {
     if (_scaleReady) return;
 
-    assert(_viewportSettings.range != null);
+    assert(_viewportSettings.range != null, 'Range must be set on the scale.');
 
     // If the viewport's domainExtent are set, then we can calculate the
     // viewport's scaleFactor now that the domainInfo has been loaded.

--- a/charts_common/lib/src/chart/cartesian/axis/numeric_tick_provider.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/numeric_tick_provider.dart
@@ -173,7 +173,10 @@ class NumericTickProvider extends BaseTickProvider<num> {
       _desiredMinTickCount = null;
     }
 
-    assert((_desiredMinTickCount == null) == (_desiredMaxTickCount == null));
+    assert(
+      (_desiredMinTickCount == null) == (_desiredMaxTickCount == null),
+      'Desired minTickCount and maxTickCount must be set together.',
+    );
   }
 
   /// Sets the allowed step sizes this tick provider can choose from.
@@ -188,14 +191,14 @@ class NumericTickProvider extends BaseTickProvider<num> {
   ///
   /// [steps] allowed step sizes in the [1, 10) range.
   set allowedSteps(List<double> steps) {
-    assert(steps.isNotEmpty);
+    assert(steps.isNotEmpty, "Allowed steps can't be empty.");
     steps.sort();
 
     final stepSet = Set.of(steps);
     _allowedSteps = List<double>.filled(stepSet.length * 3, 0);
     var stepIndex = 0;
     for (final step in stepSet) {
-      assert(1.0 <= step && step < 10.0);
+      assert(1.0 <= step && step < 10.0, 'Step must be between 1 an 10.');
       _allowedSteps[stepIndex] = _removeRoundingErrors(step / 100);
       _allowedSteps[stepSet.length + stepIndex] =
           _removeRoundingErrors(step / 10);

--- a/charts_common/lib/src/chart/cartesian/axis/ordinal_extents.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/ordinal_extents.dart
@@ -25,10 +25,13 @@ class OrdinalExtents extends Extents<String> {
   /// The elements of [range] must all be unique.
   OrdinalExtents(List<String> range) : _range = range {
     // This asserts that all elements in [range] are unique.
-    assert(() {
-      final uniqueValueCount = HashSet.of(_range).length;
-      return uniqueValueCount == range.length;
-    }());
+    assert(
+      () {
+        final uniqueValueCount = HashSet.of(_range).length;
+        return uniqueValueCount == range.length;
+      }(),
+      'Ordinal values must be unique.',
+    );
   }
 
   factory OrdinalExtents.all(List<String> range) => OrdinalExtents(range);

--- a/charts_common/lib/src/chart/cartesian/axis/ordinal_scale_domain_info.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/ordinal_scale_domain_info.dart
@@ -48,8 +48,8 @@ class OrdinalScaleDomainInfo {
   int? indexOf(String domain) => _domainsToOrder[domain];
 
   String getDomainAtIndex(int index) {
-    assert(index >= 0);
-    assert(index < _index);
+    assert(index >= 0, 'Index $index is out of bounds.');
+    assert(index < _index, 'Index $index is out of bounds.');
     return _domainList[index];
   }
 

--- a/charts_common/lib/src/chart/cartesian/axis/scale.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/scale.dart
@@ -16,7 +16,6 @@
 import 'dart:math' as math show max, min;
 
 import 'package:nimble_charts_common/src/common/math.dart';
-
 import 'package:nimble_charts_common/src/common/style/style_factory.dart'
     show StyleFactory;
 
@@ -225,6 +224,22 @@ enum RangeBandType {
 ///
 /// <p>RangeBandConfig is immutable, See factory methods for creating one.
 class RangeBandConfig {
+  /// Creates a config that assigns the rangeBand according to the stylepack.
+  ///
+  /// <p>Note: renderers can detect this setting and update the percent based on
+  /// the number of series in their preprocess.
+  RangeBandConfig.styleAssignedPercent()
+      : type = RangeBandType.styleAssignedPercentOfStep,
+        size = StyleFactory.style.rangeBandSize;
+
+  /// Creates a config that defines the rangeBand as the stepSize - pixels.
+  ///
+  /// Where fixedPixels() gave you a constant rangBand in pixels, this will give
+  /// you a constant space between rangeBands in pixels.
+  const RangeBandConfig.fixedPixelSpaceBetweenStep(double pixels)
+      : type = RangeBandType.fixedPixelSpaceFromStep,
+        size = pixels;
+
   /// Creates a rangeBand definition of zero, no rangeBand.
   const RangeBandConfig.none()
       : type = RangeBandType.none,
@@ -254,25 +269,11 @@ class RangeBandConfig {
   /// [percentOfStepWidth] is the percentage of the step from 0.0 - 1.0.
   RangeBandConfig.percentOfStep(double percentOfStepWidth)
       : type = RangeBandType.fixedPercentOfStep,
-        size = percentOfStepWidth {
-    assert(percentOfStepWidth >= 0 && percentOfStepWidth <= 1.0);
-  }
-
-  /// Creates a config that assigns the rangeBand according to the stylepack.
-  ///
-  /// <p>Note: renderers can detect this setting and update the percent based on
-  /// the number of series in their preprocess.
-  RangeBandConfig.styleAssignedPercent()
-      : type = RangeBandType.styleAssignedPercentOfStep,
-        size = StyleFactory.style.rangeBandSize;
-
-  /// Creates a config that defines the rangeBand as the stepSize - pixels.
-  ///
-  /// Where fixedPixels() gave you a constant rangBand in pixels, this will give
-  /// you a constant space between rangeBands in pixels.
-  const RangeBandConfig.fixedPixelSpaceBetweenStep(double pixels)
-      : type = RangeBandType.fixedPixelSpaceFromStep,
-        size = pixels;
+        size = percentOfStepWidth,
+        assert(
+          percentOfStepWidth >= 0 && percentOfStepWidth <= 1.0,
+          'Percent must be between 0.0 and 1.0',
+        );
   final RangeBandType type;
 
   /// The width of the band in units specified by the bandType.

--- a/charts_common/lib/src/chart/cartesian/axis/spec/date_time_axis_spec.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/spec/date_time_axis_spec.dart
@@ -88,11 +88,7 @@ class DateTimeAxisSpec extends AxisSpec<DateTime> {
       other is DateTimeAxisSpec && viewport == other.viewport && super == other;
 
   @override
-  int get hashCode {
-    var hashcode = super.hashCode;
-    hashcode = (hashcode * 37) + viewport.hashCode;
-    return hashcode;
-  }
+  int get hashCode => (super.hashCode * 37) + viewport.hashCode;
 }
 
 abstract class DateTimeTickProviderSpec extends TickProviderSpec<DateTime> {}
@@ -255,7 +251,7 @@ class BasicDateTimeTickFormatterSpec implements DateTimeTickFormatterSpec {
   /// [DateTimeFormatterFunction].
   @override
   DateTimeTickFormatter createTickFormatter(ChartContext context) {
-    assert(dateFormat != null || formatter != null);
+    assert(dateFormat != null || formatter != null, 'No formatter provided.');
     return DateTimeTickFormatter.uniform(
       SimpleTimeTickFormatter(
         formatter: dateFormat != null ? dateFormat!.format : formatter!,
@@ -271,11 +267,7 @@ class BasicDateTimeTickFormatterSpec implements DateTimeTickFormatterSpec {
           dateFormat == other.dateFormat);
 
   @override
-  int get hashCode {
-    var hash = formatter.hashCode;
-    hash = (hash * 37) * dateFormat.hashCode;
-    return hash;
-  }
+  int get hashCode => (formatter.hashCode * 37) * dateFormat.hashCode;
 }
 
 /// [TickFormatterSpec] that automatically chooses the appropriate level of

--- a/charts_common/lib/src/chart/cartesian/axis/time/auto_adjusting_date_time_tick_provider.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/time/auto_adjusting_date_time_tick_provider.dart
@@ -158,7 +158,7 @@ class AutoAdjustingDateTimeTickProvider implements TickProvider<DateTime> {
     int? minDifference;
     late TimeRangeTickProvider closestTickProvider;
 
-    assert(_potentialTickProviders.isNotEmpty);
+    assert(_potentialTickProviders.isNotEmpty, 'No tick providers available');
     for (final tickProvider in _potentialTickProviders) {
       final difference =
           (stepSize - tickProvider.getClosestStepSize(stepSize)).abs();
@@ -167,7 +167,7 @@ class AutoAdjustingDateTimeTickProvider implements TickProvider<DateTime> {
         closestTickProvider = tickProvider;
       }
     }
-    assert(minDifference != null);
+    assert(minDifference != null, 'No closest tick provider found');
     return closestTickProvider;
   }
 

--- a/charts_common/lib/src/chart/cartesian/axis/time/base_time_stepper.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/time/base_time_stepper.dart
@@ -23,7 +23,7 @@ import 'package:nimble_charts_common/src/common/date_time_factory.dart';
 abstract class BaseTimeStepper implements TimeStepper {
   BaseTimeStepper(this.dateTimeFactory) {
     // Must have at least one increment option.
-    assert(allowedTickIncrements.isNotEmpty);
+    assert(allowedTickIncrements.isNotEmpty, 'No tick increments allowed.');
   }
 
   /// The factory to generate a DateTime object.

--- a/charts_common/lib/src/chart/cartesian/axis/time/hour_time_stepper.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/time/hour_time_stepper.dart
@@ -30,6 +30,7 @@ class HourTimeStepper extends BaseTimeStepper {
     assert(
       allowedTickIncrements
           .every((increment) => increment >= 1 && increment <= 24),
+      'Increments must be between 1 and 24',
     );
 
     return HourTimeStepper._internal(dateTimeFactory, allowedTickIncrements);

--- a/charts_common/lib/src/chart/cartesian/axis/time/time_range_tick_provider_impl.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/time/time_range_tick_provider_impl.dart
@@ -101,7 +101,10 @@ class TimeRangeTickProviderImpl extends TimeRangeTickProvider {
     } else {
       allowedTickIncrements = timeStepper.allowedTickIncrements;
     }
-    assert(allowedTickIncrements.isNotEmpty);
+    assert(
+      allowedTickIncrements.isNotEmpty,
+      "Allowed tick increments can't be empty.",
+    );
 
     for (final tickIncrement in allowedTickIncrements) {
       // Create tick values with a specified increment.

--- a/charts_common/lib/src/chart/cartesian/axis/time/year_time_stepper.dart
+++ b/charts_common/lib/src/chart/cartesian/axis/time/year_time_stepper.dart
@@ -27,7 +27,10 @@ class YearTimeStepper extends BaseTimeStepper {
     // Set the default increments if null.
     allowedTickIncrements ??= _defaultIncrements;
 
-    assert(allowedTickIncrements.every((increment) => increment > 0));
+    assert(
+      allowedTickIncrements.every((increment) => increment > 0),
+      'Increments must be greater than 0',
+    );
 
     return YearTimeStepper._internal(dateTimeFactory, allowedTickIncrements);
   }

--- a/charts_common/lib/src/chart/cartesian/cartesian_renderer.dart
+++ b/charts_common/lib/src/chart/cartesian/cartesian_renderer.dart
@@ -229,7 +229,7 @@ abstract class BaseCartesianRenderer<D> extends BaseSeriesRenderer<D>
     AccessorFn<D> domainFn,
     List<Object?> data,
   ) {
-    assert(data.isNotEmpty);
+    assert(data.isNotEmpty, 'Data must not be empty.');
 
     var start = 1;
     var end = data.length - 1;

--- a/charts_common/lib/src/chart/common/behavior/calculation/percent_injector.dart
+++ b/charts_common/lib/src/chart/common/behavior/calculation/percent_injector.dart
@@ -194,9 +194,6 @@ class PercentInjector<D> implements ChartBehavior<D> {
 
           series.setAttr(percentInjectedKey, true);
         }
-
-      default:
-        throw ArgumentError('Unsupported totalType: $totalType');
     }
   }
 

--- a/charts_common/lib/src/chart/common/behavior/selection/lock_selection.dart
+++ b/charts_common/lib/src/chart/common/behavior/selection/lock_selection.dart
@@ -34,7 +34,10 @@ class LockSelection<D> implements ChartBehavior<D> {
     switch (eventTrigger) {
       case SelectionTrigger.tap:
         _listener = GestureListener(onTapTest: _onTapTest, onTap: _onSelect);
-      default:
+      case SelectionTrigger.hover:
+      case SelectionTrigger.tapAndDrag:
+      case SelectionTrigger.pressHold:
+      case SelectionTrigger.longPressHold:
         throw ArgumentError('LockSelection does not support the event '
             'trigger "$eventTrigger"');
     }
@@ -94,9 +97,7 @@ class LockSelection<D> implements ChartBehavior<D> {
       case SelectionTrigger.longPressHold:
         chart.registerTappable(this);
       case SelectionTrigger.hover:
-      default:
         chart.unregisterTappable(this);
-        break;
     }
   }
 

--- a/charts_common/lib/src/chart/common/behavior/selection/select_nearest.dart
+++ b/charts_common/lib/src/chart/common/behavior/selection/select_nearest.dart
@@ -89,7 +89,6 @@ class SelectNearest<D> implements ChartBehavior<D> {
           onDragEnd: _onDeselectAll,
         );
       case SelectionTrigger.hover:
-      default:
         _listener = GestureListener(
           onHover: hoverEventDelay == null
               ? _onSelect
@@ -99,7 +98,6 @@ class SelectNearest<D> implements ChartBehavior<D> {
                   defaultReturn: false,
                 ),
         );
-        break;
     }
   }
   late GestureListener _listener;
@@ -306,9 +304,7 @@ class SelectNearest<D> implements ChartBehavior<D> {
       case SelectionTrigger.longPressHold:
         chart.registerTappable(this);
       case SelectionTrigger.hover:
-      default:
         chart.unregisterTappable(this);
-        break;
     }
   }
 

--- a/charts_common/lib/src/chart/common/behavior/slider/slider.dart
+++ b/charts_common/lib/src/chart/common/behavior/slider/slider.dart
@@ -127,7 +127,8 @@ class Slider<D> implements ChartBehavior<D> {
           onDragUpdate: _onSelect,
           onDragEnd: _onDragEnd,
         );
-      default:
+      case SelectionTrigger.hover:
+      case SelectionTrigger.tap:
         throw ArgumentError('Slider does not support the event trigger '
             '"$eventTrigger"');
     }
@@ -437,9 +438,6 @@ class Slider<D> implements ChartBehavior<D> {
           handleReferenceY = viewBounds.top;
         case SliderHandlePosition.manual:
           handleReferenceY = positionY;
-        default:
-          throw ArgumentError('Slider does not support the handle position '
-              '"${_style.handlePosition}"');
       }
 
       // Move the slider handle along the domain axis.

--- a/charts_common/lib/src/chart/layout/layout_view.dart
+++ b/charts_common/lib/src/chart/layout/layout_view.dart
@@ -252,9 +252,12 @@ LayoutPosition layoutPosition(
         position = LayoutPosition.FullTop;
       case LayoutPosition.Right:
         position = LayoutPosition.FullRight;
-
       // Ignore other positions, like DrawArea.
-      default:
+      case LayoutPosition.DrawArea:
+      case LayoutPosition.FullBottom:
+      case LayoutPosition.FullLeft:
+      case LayoutPosition.FullTop:
+      case LayoutPosition.FullRight:
         break;
     }
   }

--- a/charts_common/lib/src/chart/sunburst/sunburst_chart.dart
+++ b/charts_common/lib/src/chart/sunburst/sunburst_chart.dart
@@ -43,7 +43,10 @@ class SunburstChart<D> extends BaseChart<D> {
       final rendererId = seriesDatum.series.getAttr(rendererIdKey);
       final renderer = getSeriesRenderer(rendererId);
 
-      assert(renderer is SunburstArcRenderer<D>);
+      assert(
+        renderer is SunburstArcRenderer<D>,
+        'Renderer must be a SunburstArcRenderer',
+      );
 
       final details = (renderer as SunburstArcRenderer<D>)
           .getExpandedDatumDetails(seriesDatum);
@@ -55,12 +58,18 @@ class SunburstChart<D> extends BaseChart<D> {
   }
 
   Rectangle<int>? get centerContentBounds {
-    assert(defaultRenderer is SunburstArcRenderer<D>);
+    assert(
+      defaultRenderer is SunburstArcRenderer<D>,
+      'Renderer must be a SunburstArcRenderer',
+    );
     return (defaultRenderer as SunburstArcRenderer<D>).centerContentBounds;
   }
 
   void expandNode(TreeNode<D> node) {
-    assert(defaultRenderer is SunburstArcRenderer<D>);
+    assert(
+      defaultRenderer is SunburstArcRenderer<D>,
+      'Renderer must be a SunburstArcRenderer',
+    );
     (defaultRenderer as SunburstArcRenderer<D>).expandNode(node);
   }
 }

--- a/charts_common/lib/src/chart/treemap/treemap_renderer_config.dart
+++ b/charts_common/lib/src/chart/treemap/treemap_renderer_config.dart
@@ -94,7 +94,7 @@ class TreeMapRendererConfig<D> extends LayoutViewConfig
           config: this,
           rendererId: customRendererId,
         );
-      default:
+      case TreeMapTileType.squarified:
         return SquarifiedTreeMapRenderer<D>(
           config: this,
           rendererId: customRendererId,

--- a/charts_common/lib/src/common/color.dart
+++ b/charts_common/lib/src/common/color.dart
@@ -104,7 +104,7 @@ class Color {
   /// Converts the character into a #RGB hex string.
   String get hexString {
     // Alpha is not included in the hex string.
-    assert(a == 255);
+    assert(a == 255, 'hexString only works for opaque colors.');
     return '#${_get2CharHex(r)}${_get2CharHex(g)}${_get2CharHex(b)}';
   }
 

--- a/charts_flutter/lib/src/behaviors/legend/series_legend.dart
+++ b/charts_flutter/lib/src/behaviors/legend/series_legend.dart
@@ -362,7 +362,6 @@ class _FlutterSeriesLegend<D> extends common.SeriesLegend<D>
         _hideSeries(detail);
 
       case common.LegendTapHandling.none:
-      default:
         break;
     }
   }

--- a/charts_flutter/lib/src/behaviors/select_nearest.dart
+++ b/charts_flutter/lib/src/behaviors/select_nearest.dart
@@ -99,9 +99,7 @@ class SelectNearest<D> extends ChartBehavior<D> {
           ..add(GestureType.onLongPress)
           ..add(GestureType.onDrag);
       case common.SelectionTrigger.hover:
-      default:
         desiredGestures.add(GestureType.onHover);
-        break;
     }
     return desiredGestures;
   }

--- a/charts_flutter/lib/src/behaviors/slider/slider.dart
+++ b/charts_flutter/lib/src/behaviors/slider/slider.dart
@@ -158,7 +158,8 @@ class Slider<D> extends ChartBehavior<D> {
           ..add(GestureType.onTap)
           ..add(GestureType.onLongPress)
           ..add(GestureType.onDrag);
-      default:
+      case common.SelectionTrigger.hover:
+      case common.SelectionTrigger.tap:
         throw ArgumentError(
           'Slider does not support the event trigger ' '"$eventTrigger"',
         );

--- a/charts_flutter/lib/src/chart_canvas.dart
+++ b/charts_flutter/lib/src/chart_canvas.dart
@@ -196,7 +196,7 @@ class ChartCanvas implements common.ChartCanvas {
         );
 
       case common.FillPatternType.solid:
-      default:
+      case null:
         // Use separate rect for drawing stroke
         _paint.color = Color.fromARGB(fill!.a, fill.r, fill.g, fill.b);
         _paint.style = PaintingStyle.fill;
@@ -212,7 +212,6 @@ class ChartCanvas implements common.ChartCanvas {
         }
 
         canvas.drawRect(_getRect(fillRectBounds), _paint);
-        break;
     }
 
     // [Canvas.drawRect] does not support drawing a rectangle with both a fill

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -63,3 +63,7 @@ words:
 - sublist
 - preprocess
 - lerp
+- rgba
+- argb
+- ltrb
+- buildable

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -61,3 +61,5 @@ words:
 - unitconverter # Probably could be capitalized
 - Unlisten
 - sublist
+- preprocess
+- lerp


### PR DESCRIPTION
I also added a few assert messages
And simplified a couple hashCode implementations
and imported a modern copy of lerpDouble from Flutter
(and fixed lerpDouble not to modify arguments)

I think these lints are probably more trouble than they're worth
but fixing some of the easy ones.