### PR TITLE
Turn Some Rules Back On in Charts Common

### DIFF
--- a/charts_common/analysis_options.yaml
+++ b/charts_common/analysis_options.yaml
@@ -9,13 +9,10 @@ analyzer:
     #return_of_invalid_type_from_closure: warning
 
     # Dangerous
-    no_runtimetype_tostring: warning
     strict_raw_type: warning
     avoid_equals_and_hash_code_on_mutable_classes: warning
     avoid_dynamic_calls: warning
     inference_failure_on_collection_literal: warning
-    type_annotate_public_apis: warning
-    inference_failure_on_untyped_parameter: warning
     inference_failure_on_instance_creation: warning
     inference_failure_on_function_invocation: warning
 
@@ -41,8 +38,8 @@ analyzer:
     prefer_null_aware_method_calls: warning
     parameter_assignments: warning
 
-
     use_late_for_private_fields_and_variables: ignore
     avoid_catches_without_on_clauses: ignore
+    avoid_annotating_with_dynamic: ignore
 
   

--- a/charts_common/lib/src/chart/bar/bar_renderer.dart
+++ b/charts_common/lib/src/chart/bar/bar_renderer.dart
@@ -138,7 +138,7 @@ class BarRenderer<D>
   }
 
   @override
-  BarRendererElement<D> getBaseDetails(datum, int index) =>
+  BarRendererElement<D> getBaseDetails(dynamic datum, int index) =>
       BarRendererElement<D>();
 
   CornerStrategy get cornerStrategy =>
@@ -158,7 +158,7 @@ class BarRenderer<D>
     required int barGroupIndex,
     required int numBarGroups,
     List<int>? dashPattern,
-    datum,
+    dynamic datum,
     Color? color,
     D? domainValue,
     num? measureValue,
@@ -576,7 +576,7 @@ class BarRendererElement<D> extends BaseBarRendererElement
   @override
   dynamic get datum => _datum;
 
-  set datum(datum) {
+  set datum(dynamic datum) {
     _datum = datum;
     index = series?.data.indexOf(datum);
   }

--- a/charts_common/lib/src/chart/bar/bar_target_line_renderer.dart
+++ b/charts_common/lib/src/chart/bar/bar_target_line_renderer.dart
@@ -142,7 +142,7 @@ class BarTargetLineRenderer<D> extends BaseBarRenderer<D,
   }
 
   @override
-  BarTargetLineRendererElement getBaseDetails(datum, int index) {
+  BarTargetLineRendererElement getBaseDetails(dynamic datum, int index) {
     final localConfig = config as BarTargetLineRendererConfig<D>;
     return BarTargetLineRendererElement(
       roundEndCaps: localConfig.roundEndCaps,
@@ -162,7 +162,7 @@ class BarTargetLineRenderer<D> extends BaseBarRenderer<D,
     required ImmutableAxis<num> measureAxis,
     required int barGroupIndex,
     required int numBarGroups,
-    datum,
+    dynamic datum,
     Color? color,
     List<int>? dashPattern,
     D? domainValue,

--- a/charts_common/lib/src/chart/bar/base_bar_renderer.dart
+++ b/charts_common/lib/src/chart/bar/base_bar_renderer.dart
@@ -350,7 +350,7 @@ abstract class BaseBarRenderer<D, R extends BaseBarRendererElement,
   /// This is intended to be overridden by child classes that need to add
   /// customized rendering properties.
   @protected
-  R getBaseDetails(datum, int index);
+  R getBaseDetails(dynamic datum, int index);
 
   @override
   void configureDomainAxes(List<MutableSeries<D>> seriesList) {
@@ -539,7 +539,7 @@ abstract class BaseBarRenderer<D, R extends BaseBarRendererElement,
     required num measureOffsetValue,
     required ImmutableAxis<num> measureAxis,
     required int numBarGroups,
-    datum,
+    dynamic datum,
     double? previousBarGroupWeight,
     double? barGroupWeight,
     List<double>? allBarGroupWeights,

--- a/charts_common/lib/src/chart/line/line_renderer.dart
+++ b/charts_common/lib/src/chart/line/line_renderer.dart
@@ -1152,7 +1152,7 @@ class LineRenderer<D> extends BaseCartesianRenderer<D> {
   bool get isRtl => _chart?.context.isRtl ?? false;
 
   _DatumPoint<D> _getPoint(
-    datum,
+    dynamic datum,
     D? domainValue,
     ImmutableSeries<D> series,
     ImmutableAxis<D> domainAxis,

--- a/charts_common/test/data/graph_utils_test.dart
+++ b/charts_common/test/data/graph_utils_test.dart
@@ -188,8 +188,8 @@ void main() {
 
   group('accessorIfExists', () {
     test('calls function when not null', () {
-      dynamic getDomain(node, _) => node.domainId;
-      dynamic getMeasure(node, _) => node.measure;
+      dynamic getDomain(dynamic node, _) => node.domainId;
+      dynamic getMeasure(dynamic node, _) => node.measure;
 
       expect(
         accessorIfExists(


### PR DESCRIPTION
Turn on:
- no_runtimetype_tostring
- type_annotate_public_apis, 
- inference_failure_on_untyped_parameter