### PR TITLE
Turn Strict_raw_type Back On

### DIFF
--- a/charts_common/analysis_options.yaml
+++ b/charts_common/analysis_options.yaml
@@ -9,7 +9,6 @@ analyzer:
     #return_of_invalid_type_from_closure: warning
 
     # Dangerous
-    strict_raw_type: warning
     avoid_equals_and_hash_code_on_mutable_classes: warning
     avoid_dynamic_calls: warning
     inference_failure_on_collection_literal: warning

--- a/charts_common/lib/src/chart/pie/arc_label_decorator.dart
+++ b/charts_common/lib/src/chart/pie/arc_label_decorator.dart
@@ -219,7 +219,7 @@ class ArcLabelDecorator<D> extends ArcRendererDecorator<D> {
     TextStyle labelStyle,
     int insideArcWidth,
     int outsideArcWidth,
-    ArcRendererElement arcRendererElement,
+    ArcRendererElement<D> arcRendererElement,
     ArcLabelPosition labelPosition,
   ) {
     if (labelPosition == ArcLabelPosition.auto) {

--- a/charts_common/lib/src/chart/sunburst/sunburst_arc_label_decorator.dart
+++ b/charts_common/lib/src/chart/sunburst/sunburst_arc_label_decorator.dart
@@ -167,13 +167,15 @@ class SunburstArcLabelDecorator<D> extends ArcLabelDecorator<D> {
     TextStyle labelStyle,
     int insideArcWidth,
     int outsideArcWidth,
-    ArcRendererElement arcRendererElement,
+    ArcRendererElement<D> arcRendererElement,
     ArcLabelPosition labelPosition,
   ) {
     assert(arcRendererElement is SunburstArcRendererElement);
 
-    if ((arcRendererElement as SunburstArcRendererElement).isOuterMostRing ==
-        true) {
+    final sunburstArcRendererElement =
+        arcRendererElement as SunburstArcRendererElement<D>;
+
+    if (sunburstArcRendererElement.isOuterMostRing ?? false) {
       return super.calculateLabelPosition(
         labelElement,
         labelStyle,

--- a/charts_common/lib/src/chart/sunburst/sunburst_arc_renderer.dart
+++ b/charts_common/lib/src/chart/sunburst/sunburst_arc_renderer.dart
@@ -68,7 +68,7 @@ class SunburstArcRenderer<D> extends BaseArcRenderer<D> {
   final _seriesArcMap = LinkedHashMap<String, List<AnimatedArcList<D>>>();
 
   final _nodeToArcRenderElementMap =
-      <TreeNode<D>, SunburstArcRendererElement>{};
+      <TreeNode<D>, SunburstArcRendererElement<D>>{};
 
   // Store a list of arcs that exist in the series data.
   //
@@ -336,7 +336,7 @@ class SunburstArcRenderer<D> extends BaseArcRenderer<D> {
                 arcKey,
                 datum,
                 //TODO: dangerous casts
-                domainValue as D?,
+                domainValue,
               )..setNewTarget(
                   SunburstArcRendererElement<D>(
                     color: colorFn!(arcIndex),
@@ -357,7 +357,7 @@ class SunburstArcRenderer<D> extends BaseArcRenderer<D> {
             }
 
             // TODO: this could be a dangerous cast
-            animatingArc.domain = domainValue as D?;
+            animatingArc.domain = domainValue;
 
             // Update the set of arcs that still exist in the series data.
             _currentKeys.add(arcKey);

--- a/charts_common/lib/src/data/graph.dart
+++ b/charts_common/lib/src/data/graph.dart
@@ -128,11 +128,14 @@ class Graph<N, L, D> {
   /// Store additional key-value pairs for link attributes
   final LinkAttributes linkAttributes = LinkAttributes();
 
+  //TODO: looks like there is something off about the graph types
+  //because dynamic is necessary
+
   /// Transform graph data given by links and nodes into a [Series] list.
   ///
   /// Output should contain two [Series] with the format:
   /// `[Series<Node<N,L>> nodeSeries, Series<Link<N,L>> linkSeries]`
-  List<Series<GraphElement, D>> toSeriesList() {
+  List<Series<GraphElement<dynamic>, D>> toSeriesList() {
     final nodeSeries = Series<Node<N, L>, D>(
       id: '${id}_nodes',
       data: nodes,

--- a/charts_common/test/chart/bar/bar_renderer_test.dart
+++ b/charts_common/test/chart/bar/bar_renderer_test.dart
@@ -44,7 +44,7 @@ class FakeBarRenderer<D> extends BarRenderer<D> {
   List<List<BarRendererElement<D>>> elementsPainted = [];
 
   factory FakeBarRenderer({
-    required BarRendererConfig config,
+    required BarRendererConfig<dynamic> config,
     required String rendererId,
   }) =>
       FakeBarRenderer._internal(config: config, rendererId: rendererId);
@@ -67,7 +67,7 @@ class FakeBarRenderer<D> extends BarRenderer<D> {
 
 void main() {
   // ignore: unused_local_variable
-  late BarRenderer renderer;
+  late BarRenderer<dynamic> renderer;
   late List<MutableSeries<String>> seriesList;
   late List<MutableSeries<String>> groupedStackedSeriesList;
 
@@ -75,8 +75,8 @@ void main() {
   // Convenience methods for creating mocks.
   /////////////////////////////////////////
   // ignore: no_leading_underscores_for_local_identifiers
-  BaseBarRenderer _configureBaseRenderer(
-    BaseBarRenderer renderer,
+  BaseBarRenderer<dynamic, dynamic, dynamic> _configureBaseRenderer(
+    BaseBarRenderer<dynamic, dynamic, dynamic> renderer,
     bool vertical,
   ) {
     final context = MockChartContext();
@@ -90,13 +90,17 @@ void main() {
     return renderer;
   }
 
-  BarRenderer makeRenderer({required BarRendererConfig config}) {
+  BarRenderer<dynamic> makeRenderer({
+    required BarRendererConfig<dynamic> config,
+  }) {
     final renderer = BarRenderer(config: config);
     _configureBaseRenderer(renderer, true);
     return renderer;
   }
 
-  FakeBarRenderer makeFakeRenderer({required BarRendererConfig config}) {
+  FakeBarRenderer<dynamic> makeFakeRenderer({
+    required BarRendererConfig<dynamic> config,
+  }) {
     final renderer = FakeBarRenderer<dynamic>(
       config: config,
       rendererId: '123',

--- a/charts_common/test/chart/common/behavior/calculation/percent_injector_test.dart
+++ b/charts_common/test/chart/common/behavior/calculation/percent_injector_test.dart
@@ -39,18 +39,20 @@ class MyRow {
   final int clickCountUpper;
 }
 
-class MockChart extends Mock implements CartesianChart {
-  LifecycleListener? lastLifecycleListener;
+class MockChart extends Mock implements CartesianChart<dynamic> {
+  LifecycleListener<dynamic>? lastLifecycleListener;
 
   @override
   bool vertical = true;
 
   @override
-  LifecycleListener addLifecycleListener(LifecycleListener listener) =>
+  LifecycleListener<dynamic> addLifecycleListener(
+    LifecycleListener<dynamic> listener,
+  ) =>
       lastLifecycleListener = listener;
 
   @override
-  bool removeLifecycleListener(LifecycleListener listener) {
+  bool removeLifecycleListener(LifecycleListener<dynamic> listener) {
     expect(listener, equals(lastLifecycleListener));
     lastLifecycleListener = null;
     return true;
@@ -61,7 +63,7 @@ void main() {
   late MockChart chart;
   late List<MutableSeries<String>> seriesList;
 
-  PercentInjector makeBehavior({
+  PercentInjector<dynamic> makeBehavior({
     PercentInjectorTotalType totalType = PercentInjectorTotalType.domain,
   }) {
     final behavior = PercentInjector(totalType: totalType);

--- a/charts_common/test/mox.dart
+++ b/charts_common/test/mox.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: strict_raw_type
+
 import 'package:mockito/annotations.dart';
 import 'package:nimble_charts_common/common.dart';
 


### PR DESCRIPTION
This is forces us to declare generic type arguments when the compiler would otherwise infer dynamic. It just makes dynamic type arguments more explicit