### PR TITLE
Replace deprecated hashValues method with Object.hash

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.2"
+          flutter-version: "${{ vars.FLUTTER_VERSION }}"
           channel: "stable"
           architecture: x64
 

--- a/.github/workflows/deploy_wasm_to_pages.yml
+++ b/.github/workflows/deploy_wasm_to_pages.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.2"
+          flutter-version: "${{ vars.FLUTTER_VERSION }}"
           channel: "stable"
           architecture: x64
 

--- a/.github/workflows/generate_goldens.yaml
+++ b/.github/workflows/generate_goldens.yaml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.24.2"
+          flutter-version: "${{ vars.FLUTTER_VERSION }}"
           channel: "stable"
           architecture: x64
 

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ charts_common/.DS_Store
 charts_common/test/chart/.DS_Store
 
 .DS_Store
+
+.idea/

--- a/charts_flutter/lib/src/behaviors/a11y/domain_a11y_explore_behavior.dart
+++ b/charts_flutter/lib/src/behaviors/a11y/domain_a11y_explore_behavior.dart
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart'
     show ChartBehavior, GestureType;
 import 'package:nimble_charts_common/common.dart' as common
@@ -110,7 +109,7 @@ class DomainA11yExploreBehavior<D> extends ChartBehavior<D> {
       exploreModeDisabledAnnouncement == other.exploreModeDisabledAnnouncement;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         minimumWidth,
         vocalizationCallback,
         exploreModeTrigger,

--- a/charts_flutter/lib/src/behaviors/calculation/percent_injector.dart
+++ b/charts_flutter/lib/src/behaviors/calculation/percent_injector.dart
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
-import 'package:nimble_charts/flutter.dart';
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart';
 import 'package:nimble_charts_common/common.dart' as common;
 

--- a/charts_flutter/lib/src/behaviors/chart_title/chart_title.dart
+++ b/charts_flutter/lib/src/behaviors/chart_title/chart_title.dart
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart'
     show ChartBehavior, GestureType;
@@ -184,7 +183,7 @@ class ChartTitle<D> extends ChartBehavior<D> {
       outerPadding == other.outerPadding;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         behaviorPosition,
         layoutMinSize,
         layoutPreferredSize,

--- a/charts_flutter/lib/src/behaviors/domain_highlighter.dart
+++ b/charts_flutter/lib/src/behaviors/domain_highlighter.dart
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
-import 'package:nimble_charts/flutter.dart';
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart';
 import 'package:nimble_charts_common/common.dart' as common;
 

--- a/charts_flutter/lib/src/behaviors/legend/datum_legend.dart
+++ b/charts_flutter/lib/src/behaviors/legend/datum_legend.dart
@@ -279,7 +279,7 @@ class DatumLegend<D> extends ChartBehavior<D> {
       entryTextStyle == other.entryTextStyle;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         selectionModelType,
         contentBuilder,
         position,

--- a/charts_flutter/lib/src/behaviors/legend/legend_content_builder.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_content_builder.dart
@@ -98,5 +98,5 @@ class TabularLegendContentBuilder extends BaseLegendContentBuilder {
       legendLayout == other.legendLayout;
 
   @override
-  int get hashCode => hashValues(legendEntryLayout, legendLayout);
+  int get hashCode => Object.hash(legendEntryLayout, legendLayout);
 }

--- a/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
+++ b/charts_flutter/lib/src/behaviors/legend/legend_layout.dart
@@ -99,7 +99,7 @@ class TabularLegendLayout implements LegendLayout {
       cellPadding == other.cellPadding;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         desiredMaxRows,
         desiredMaxColumns,
         isHorizontalFirst,

--- a/charts_flutter/lib/src/behaviors/legend/series_legend.dart
+++ b/charts_flutter/lib/src/behaviors/legend/series_legend.dart
@@ -294,7 +294,7 @@ class SeriesLegend<D> extends ChartBehavior<D> {
       entryTextStyle == other.entryTextStyle;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         selectionModelType,
         contentBuilder,
         position,

--- a/charts_flutter/lib/src/behaviors/line_point_highlighter.dart
+++ b/charts_flutter/lib/src/behaviors/line_point_highlighter.dart
@@ -15,7 +15,6 @@
 
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:nimble_charts/flutter.dart';
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart';
 import 'package:nimble_charts_common/common.dart' as common;
 
@@ -107,7 +106,7 @@ class LinePointHighlighter<D> extends ChartBehavior<D> {
       drawFollowLinesAcrossChart == other.drawFollowLinesAcrossChart;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         selectionModelType,
         defaultRadiusPx,
         radiusPaddingPx,

--- a/charts_flutter/lib/src/behaviors/range_annotation.dart
+++ b/charts_flutter/lib/src/behaviors/range_annotation.dart
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import 'package:collection/collection.dart' show ListEquality;
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart'
     show ChartBehavior, GestureType;
@@ -115,7 +114,7 @@ class RangeAnnotation<D> extends ChartBehavior<D> {
       layoutPaintOrder == other.layoutPaintOrder;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         annotations,
         defaultColor,
         extendAxis,

--- a/charts_flutter/lib/src/behaviors/select_nearest.dart
+++ b/charts_flutter/lib/src/behaviors/select_nearest.dart
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
-import 'package:nimble_charts/flutter.dart';
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart';
 import 'package:nimble_charts_common/common.dart' as common;
 

--- a/charts_flutter/lib/src/behaviors/slider/slider.dart
+++ b/charts_flutter/lib/src/behaviors/slider/slider.dart
@@ -15,7 +15,6 @@
 
 import 'dart:math' show Rectangle;
 
-import 'package:flutter/widgets.dart' show hashValues;
 import 'package:meta/meta.dart' show immutable;
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart'
     show ChartBehavior, GestureType;
@@ -197,7 +196,7 @@ class Slider<D> extends ChartBehavior<D> {
       layoutPaintOrder == other.layoutPaintOrder;
 
   @override
-  int get hashCode => hashValues(
+  int get hashCode => Object.hash(
         eventTrigger,
         handleRenderer,
         initialDomainValue,

--- a/charts_flutter/lib/src/behaviors/sliding_viewport.dart
+++ b/charts_flutter/lib/src/behaviors/sliding_viewport.dart
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 import 'package:flutter/material.dart';
-import 'package:nimble_charts/flutter.dart';
 import 'package:nimble_charts/src/behaviors/chart_behavior.dart';
 import 'package:nimble_charts_common/common.dart' as common;
 

--- a/charts_flutter/lib/src/text_style.dart
+++ b/charts_flutter/lib/src/text_style.dart
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:ui' show hashValues;
 import 'package:nimble_charts_common/common.dart' as common
     show Color, TextStyle;
 
@@ -40,5 +39,5 @@ class TextStyle implements common.TextStyle {
 
   @override
   int get hashCode =>
-      hashValues(fontSize, fontFamily, color, lineHeight, fontWeight);
+      Object.hash(fontSize, fontFamily, color, lineHeight, fontWeight);
 }

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -12,6 +12,8 @@ ignorePaths:
   - "gradlew.bat"
   - "build"
   - "*.iml"
+  - "*.yml"
+  - "*.yaml"
   - "charts_common/test/data/"
   - 'coverage'
 words:

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -7,6 +7,7 @@ ignorePaths:
   - charts_flutter/example/ios/
   - charts_flutter/example/linux/
   - charts_flutter/example/android/
+  - .gitignore
   - "gradlew"
   - "gradlew.bat"
   - "build"
@@ -69,4 +70,3 @@ words:
 - buildable
 - abdushakoor
 - eseidel
-- xcconfig

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -69,3 +69,4 @@ words:
 - buildable
 - abdushakoor
 - eseidel
+- xcconfig


### PR DESCRIPTION
`hashValues` is not exported anymore in Flutter 2.27.0. This PR replaces it with [Object.hash](https://api.dart.dev/stable/3.4.0/dart-core/Object/hash.html).

Ref: https://github.com/flutter/flutter/issues/151679