### PR TITLE
Fix MaterialPalette.gray type

### DIFF
--- a/charts_common/lib/src/common/material_palette.dart
+++ b/charts_common/lib/src/common/material_palette.dart
@@ -35,7 +35,7 @@ class MaterialPalette {
   static Palette get indigo => const MaterialIndigo();
   static Palette get pink => const MaterialPink();
   static Palette get teal => const MaterialTeal();
-  static MaterialGray get gray => const MaterialGray();
+  static Palette get gray => const MaterialGray();
 
   // Lazily-instantiated iterable, to avoid allocating colors that are not used.
   static final Iterable<Palette> _orderedPalettes = [


### PR DESCRIPTION
All `MaterialPalette.{color}` returns a `Palette` except `MaterialPalette.gray` which returns a `MaterialGray`.
This PR aligns the type to `Palette`.